### PR TITLE
Bump Flink dependency to 1.15.4

### DIFF
--- a/java/AvroGlueSchemaRegistryKafka/README.md
+++ b/java/AvroGlueSchemaRegistryKafka/README.md
@@ -1,6 +1,6 @@
 ## AVRO serialization in KafkaSource and KafkaSink using AWS Glue Schema Registry
 
-* Flink version: 1.15.2
+* Flink version: 1.15
 * Flink API: DataStream API
 * Language: Java (11)
 

--- a/java/AvroGlueSchemaRegistryKafka/pom.xml
+++ b/java/AvroGlueSchemaRegistryKafka/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.amazonaws</groupId>
-    <artifactId>avro-gsr-kafka-flink-app</artifactId>
+    <artifactId>avro-gsr-kafka-flink</artifactId>
     <version>1.0-SNAPSHOT</version>
 
     <properties>
@@ -18,7 +18,7 @@
         <avro.version>1.10.2</avro.version>
         <kafka.clients.version>2.8.1</kafka.clients.version>
 
-        <flink.version>1.15.2</flink.version>
+        <flink.version>1.15.4</flink.version>
         <kda.connectors.version>2.1.0</kda.connectors.version>
         <kda.runtime.version>1.2.0</kda.runtime.version>
         <aws.sdk.version>1.1.6</aws.sdk.version>

--- a/java/AvroGlueSchemaRegistryKinesis/README.md
+++ b/java/AvroGlueSchemaRegistryKinesis/README.md
@@ -1,6 +1,6 @@
 # AVRO serialization in FlinkKinesisConsumer and KinesisStreamsSink using AWS Glue Schema Registry
 
-* Flink version: 1.15.2
+* Flink version: 1.15
 * Flink API: DataStream API
 * Language Java (11)
 

--- a/java/AvroGlueSchemaRegistryKinesis/pom.xml
+++ b/java/AvroGlueSchemaRegistryKinesis/pom.xml
@@ -8,7 +8,7 @@
   <artifactId>flink-kds-gsr</artifactId>
   <version>1.0-SNAPSHOT</version>
 
-  <name>flink-kds-gsr</name>
+  <name>avro-gsr-kds-flink</name>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -19,11 +19,9 @@
     <scala.binary.version>2.12</scala.binary.version>
     <avro.version>1.10.2</avro.version>
 
-    <flink.version>1.15.2</flink.version>
+    <flink.version>1.15.4</flink.version>
     <kda.connectors.version>2.1.0</kda.connectors.version>
     <kda.runtime.version>1.2.0</kda.runtime.version>
-    <!-- We are not using 1.15.2 because there are known bugs that were fixed in 1.15.3 for FlinkKinesisConsumer not respecting Credential Provider configuration for EFO FLINK-29205-->
-    <flink.kds.connector.version>1.15.3</flink.kds.connector.version>
 
     <slf4j.version>1.7.32</slf4j.version>
     <log4j.version>2.17.2</log4j.version>
@@ -74,12 +72,12 @@
     <dependency>
       <groupId>org.apache.flink</groupId>
       <artifactId>flink-connector-kinesis</artifactId>
-      <version>${flink.kds.connector.version}</version>
+      <version>${flink.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.flink</groupId>
       <artifactId>flink-connector-aws-kinesis-streams</artifactId>
-      <version>${flink.kds.connector.version}</version>
+      <version>${flink.version}</version>
     </dependency>
 
     <!-- AVRO -->

--- a/java/GettingStarted/README.md
+++ b/java/GettingStarted/README.md
@@ -2,7 +2,7 @@
 
 Skeleton project for a basic Flink Java application to run on Amazon Managed Service for Apache Flink.
 
-* Flink version: 1.15.2
+* Flink version: 1.15
 * Flink API: DataStream API
 * Language: Java (11)
 

--- a/java/GettingStarted/pom.xml
+++ b/java/GettingStarted/pom.xml
@@ -14,9 +14,8 @@
         <target.java.version>11</target.java.version>
         <maven.compiler.source>${target.java.version}</maven.compiler.source>
         <maven.compiler.target>${target.java.version}</maven.compiler.target>
-        <flink.version>1.15.2</flink.version>
+        <flink.version>1.15.4</flink.version>
         <kda.runtime.version>1.2.0</kda.runtime.version>
-        <flink.kds.connector.version>1.15.4</flink.kds.connector.version><!-- We are not using 1.15.2 because there are known bugs that were fixed in 1.15.4 for FlinkKinesisConsumer not respecting Credential Provider configuration for EFO FLINK-29205-->
         <scala.binary.version>2.12</scala.binary.version>
         <log4j.version>2.17.1</log4j.version>
     </properties>
@@ -67,7 +66,7 @@
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-connector-kinesis</artifactId>
-            <version>${flink.kds.connector.version}</version>
+            <version>${flink.version}</version>
         </dependency>
 
 

--- a/java/GettingStartedTable/README.md
+++ b/java/GettingStartedTable/README.md
@@ -2,7 +2,7 @@
 
 Example of project for a basic Flink Java application using the TableAPI or SQL.
 
-* Flink version: 1.15.2
+* Flink version: 1.15
 * Flink API: Table API or SQL
 * Language: Java (11)
 

--- a/java/GettingStartedTable/pom.xml
+++ b/java/GettingStartedTable/pom.xml
@@ -14,7 +14,7 @@
         <target.java.version>11</target.java.version>
         <maven.compiler.source>${target.java.version}</maven.compiler.source>
         <maven.compiler.target>${target.java.version}</maven.compiler.target>
-        <flink.version>1.15.2</flink.version>
+        <flink.version>1.15.4</flink.version>
         <scala.binary.version>2.12</scala.binary.version>
         <kda.runtime.version>1.2.0</kda.runtime.version>
         <log4j.version>2.17.1</log4j.version>

--- a/java/KafkaConnectors/README.md
+++ b/java/KafkaConnectors/README.md
@@ -1,6 +1,6 @@
 ## Flink Kafka Source & Sink Examples
 
-* Flink version: 1.15.2
+* Flink version: 1.15
 * Flink API: DataStream API
 * Language: Java (11)
 

--- a/java/KafkaConnectors/pom.xml
+++ b/java/KafkaConnectors/pom.xml
@@ -14,7 +14,7 @@
         <target.java.version>11</target.java.version>
         <maven.compiler.source>${target.java.version}</maven.compiler.source>
         <maven.compiler.target>${target.java.version}</maven.compiler.target>
-        <flink.version>1.15.2</flink.version>
+        <flink.version>1.15.4</flink.version>
         <kda.runtime.version>1.2.0</kda.runtime.version>
         <log4j.version>2.17.1</log4j.version>
     </properties>

--- a/java/KafkaCustomKeystoreWithConfigProviders/README.md
+++ b/java/KafkaCustomKeystoreWithConfigProviders/README.md
@@ -1,6 +1,6 @@
 ## Sample illustrating how to use MSK config providers in Flink Kafka connectors
 
-* Flink version: 1.15.2
+* Flink version: 1.15
 * Flink API: DataStream API
 * Language: Java (11)
 

--- a/java/KafkaCustomKeystoreWithConfigProviders/pom.xml
+++ b/java/KafkaCustomKeystoreWithConfigProviders/pom.xml
@@ -14,7 +14,7 @@
         <target.java.version>11</target.java.version>
         <maven.compiler.source>${target.java.version}</maven.compiler.source>
         <maven.compiler.target>${target.java.version}</maven.compiler.target>
-        <flink.version>1.15.2</flink.version>
+        <flink.version>1.15.4</flink.version>
         <kda.runtime.version>1.2.0</kda.runtime.version>
         <jackson.databind.version>2.13.4.2</jackson.databind.version>
         <jackson.version>2.13.4</jackson.version>

--- a/java/KinesisConnectors/README.md
+++ b/java/KinesisConnectors/README.md
@@ -1,6 +1,6 @@
 # Flink Kinesis Source & Sink examples (standard and EFO)
 
-* Flink version: 1.15.2
+* Flink version: 1.15
 * Flink API: DataStream API
 * Language: Java (11)
 

--- a/java/KinesisConnectors/pom.xml
+++ b/java/KinesisConnectors/pom.xml
@@ -14,10 +14,8 @@
         <target.java.version>11</target.java.version>
         <maven.compiler.source>${target.java.version}</maven.compiler.source>
         <maven.compiler.target>${target.java.version}</maven.compiler.target>
-        <flink.version>1.15.2</flink.version>
+        <flink.version>1.15.4</flink.version>
         <kda.runtime.version>1.2.0</kda.runtime.version>
-        <!-- We are not using 1.15.2 because there are known bugs that were fixed in 1.15.4 for FlinkKinesisConsumer not respecting Credential Provider configuration for EFO FLINK-29205-->
-        <flink.kds.connector.version>1.15.4</flink.kds.connector.version>
         <log4j.version>2.17.1</log4j.version>
     </properties>
 
@@ -47,12 +45,12 @@
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-connector-kinesis</artifactId>
-            <version>${flink.kds.connector.version}</version>
+            <version>${flink.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-connector-aws-kinesis-streams</artifactId>
-            <version>${flink.kds.connector.version}</version>
+            <version>${flink.version}</version>
         </dependency>
 
         <!-- Logging framework, to produce console output when running in the IDE. -->

--- a/java/KinesisFirehoseSink/README.md
+++ b/java/KinesisFirehoseSink/README.md
@@ -1,6 +1,6 @@
 # Flink Kinesis Firehose Sink example
 
-* Flink version: 1.15.2
+* Flink version: 1.15
 * Flink API: DataStream API
 * Language: Java (11)
 

--- a/java/KinesisFirehoseSink/pom.xml
+++ b/java/KinesisFirehoseSink/pom.xml
@@ -14,10 +14,8 @@
         <target.java.version>11</target.java.version>
         <maven.compiler.source>${target.java.version}</maven.compiler.source>
         <maven.compiler.target>${target.java.version}</maven.compiler.target>
-        <flink.version>1.15.2</flink.version>
+        <flink.version>1.15.4</flink.version>
         <kda.runtime.version>1.2.0</kda.runtime.version>
-        <!-- We are not using 1.15.2 because there are known bugs that were fixed in 1.15.4 for FlinkKinesisConsumer not respecting Credential Provider configuration for EFO FLINK-29205-->
-        <flink.kds.connector.version>1.15.4</flink.kds.connector.version>
         <log4j.version>2.17.1</log4j.version>
     </properties>
 
@@ -47,12 +45,12 @@
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-connector-kinesis</artifactId>
-            <version>${flink.kds.connector.version}</version>
+            <version>${flink.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-connector-aws-kinesis-streams</artifactId>
-            <version>${flink.kds.connector.version}</version>
+            <version>${flink.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>

--- a/java/S3ParquetSink/README.md
+++ b/java/S3ParquetSink/README.md
@@ -1,6 +1,6 @@
 # S3 Parquet Sink
 
-* Flink version: 1.15.2
+* Flink version: 1.15
 * Flink API: DataStream API
 * Language Java (11)
 

--- a/java/S3ParquetSink/pom.xml
+++ b/java/S3ParquetSink/pom.xml
@@ -17,12 +17,9 @@
         <scala.binary.version>2.12</scala.binary.version>
         <avro.version>1.10.2</avro.version>
 
-        <flink.version>1.15.2</flink.version>
+        <flink.version>1.15.4</flink.version>
         <kda.connectors.version>2.1.0</kda.connectors.version>
         <kda.runtime.version>1.2.0</kda.runtime.version>
-        <!-- We are not using 1.15.2 because there are known bugs that were fixed in 1.15.3 for FlinkKinesisConsumer not respecting Credential Provider configuration for EFO FLINK-29205-->
-        <flink.kds.connector.version>1.15.3</flink.kds.connector.version>
-
         <slf4j.version>1.7.32</slf4j.version>
         <log4j.version>2.17.2</log4j.version>
         <junit.version>5.9.1</junit.version>
@@ -106,12 +103,12 @@
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-connector-kinesis</artifactId>
-            <version>${flink.kds.connector.version}</version>
+            <version>${flink.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-connector-aws-kinesis-streams</artifactId>
-            <version>${flink.kds.connector.version}</version>
+            <version>${flink.version}</version>
         </dependency>
         <!-- Parquet -->
 

--- a/java/S3Sink/README.md
+++ b/java/S3Sink/README.md
@@ -1,6 +1,6 @@
 # S3 Sink
 
-* Flink version: 1.15.2
+* Flink version: 1.15
 * Flink API: DataStream API
 * Language Java (11)
 

--- a/java/S3Sink/pom.xml
+++ b/java/S3Sink/pom.xml
@@ -17,12 +17,9 @@
         <scala.binary.version>2.12</scala.binary.version>
         <avro.version>1.10.2</avro.version>
 
-        <flink.version>1.15.2</flink.version>
+        <flink.version>1.15.4</flink.version>
         <kda.connectors.version>2.1.0</kda.connectors.version>
         <kda.runtime.version>1.2.0</kda.runtime.version>
-        <!-- We are not using 1.15.2 because there are known bugs that were fixed in 1.15.3 for FlinkKinesisConsumer not respecting Credential Provider configuration for EFO FLINK-29205-->
-        <flink.kds.connector.version>1.15.3</flink.kds.connector.version>
-
         <slf4j.version>1.7.32</slf4j.version>
         <log4j.version>2.17.2</log4j.version>
         <junit.version>5.9.1</junit.version>
@@ -96,12 +93,12 @@
     <dependency>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-connector-kinesis</artifactId>
-        <version>${flink.kds.connector.version}</version>
+        <version>${flink.version}</version>
     </dependency>
     <dependency>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-connector-aws-kinesis-streams</artifactId>
-        <version>${flink.kds.connector.version}</version>
+        <version>${flink.version}</version>
     </dependency>
         <!-- Add logging framework, to produce console output when running in the IDE. -->
         <!-- These dependencies are excluded from the application JAR by default. -->

--- a/java/Windowing/README.md
+++ b/java/Windowing/README.md
@@ -2,7 +2,7 @@
 
 Example of project for a basic Flink Java application using Tumbling and Sliding windows.
 
-* Flink version: 1.15.2
+* Flink version: 1.15
 * Flink API: DataStream API
 * Flink Connectors: Kafka Connector, Kinesis Connector
 * Language: Java (11)

--- a/java/Windowing/pom.xml
+++ b/java/Windowing/pom.xml
@@ -14,8 +14,7 @@
         <target.java.version>11</target.java.version>
         <maven.compiler.source>${target.java.version}</maven.compiler.source>
         <maven.compiler.target>${target.java.version}</maven.compiler.target>
-        <flink.version>1.15.2</flink.version>
-        <flink.kds.connector.version>1.15.4</flink.kds.connector.version>
+        <flink.version>1.15.4</flink.version>
         <scala.binary.version>2.12</scala.binary.version>
         <kda.runtime.version>1.2.0</kda.runtime.version>
         <log4j.version>2.17.1</log4j.version>
@@ -65,7 +64,7 @@
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-connector-kinesis</artifactId>
-            <version>${flink.kds.connector.version}</version>
+            <version>${flink.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>


### PR DESCRIPTION
Bump Flink dependency in Java examples to 1.15.4