### PR TITLE
Fix typos in Python local dockerized environment instructions

### DIFF
--- a/python/LocalDevelopmentOnAppleSilicon/README.md
+++ b/python/LocalDevelopmentOnAppleSilicon/README.md
@@ -2,7 +2,7 @@
 
 ### Problem
 
-There are known issues with installing PyFlink dependencies on Mac using Apple Silicon chips (see [FLINK-26981](https://issues.apache.org/jira/browse/FLINK-26981)). These issues, resolved in Flink 1.16.x, make difficult to develop PyFlink 1.15.x applications on new Mac machines, using IDE like PyCharm or Visual Studio Code.
+There are known issues with installing PyFlink dependencies on Mac using Apple Silicon chips (see [FLINK-26981](https://issues.apache.org/jira/browse/FLINK-26981)). These issues, resolved in Flink 1.16.x, make it difficult to develop PyFlink 1.15.x applications on new Mac machines, using IDE like PyCharm or Visual Studio Code.
 
 ### Solution overview
 

--- a/python/README.md
+++ b/python/README.md
@@ -16,7 +16,7 @@ To learn how to package multiple dependencies in a PyFlink application to run on
 ### Developing PyFlink on Apple Silicon macOS
 
 PyFlink version 1.15 has [known issues](https://issues.apache.org/jira/browse/FLINK-25188) on macOS machines using Apple Silicon chips (e.g. M1) due to Python dependencies.
-You cannot directly install the `apache-pyflink==1.15.4` library on the machine, directly. This makes challenging developing PyFlink 1.15 applications on Apple Silicon.
+You cannot install the `apache-pyflink==1.15.4` library on the machine, directly. This make it difficult to develop PyFlink 1.15 applications on Apple Silicon.
 
 A workaround is running the Python interpreter in a Docker container built for Intel architecture, and running it in the M1 machine using the Rosetta emulation.
 


### PR DESCRIPTION
Just Typo fixes