### PR TITLE
Custom TypeInfo example

### DIFF
--- a/java/Serialization/CustomTypeInfo/README.md
+++ b/java/Serialization/CustomTypeInfo/README.md
@@ -76,6 +76,19 @@ and [`AggregateVehicleEventSerializationTest`](src/test/java/com/amazonaws/servi
 These tests use a test utility class that can be reused to test any record class:
 [`FlinkSerializationTestUtils`](src/test/java/com/amazonaws/services/msf/domain/FlinkSerializationTestUtils.java)
 
+#### More serialization cases 
+
+The test class [MoreKryoSerializationExamplesTest](src/test/java/com/amazonaws/services/msf/domain/MoreKryoSerializationExamplesTest.java)
+illustrates more cases where serialization does or does not fall back to Kryo.
+
+Serialization tests are `@Disabled` for those cases where Kryo is used. You can enable these tests to observe how they
+actually catch the Kryo fallback.
+
+In particular:
+* Any Collection falls back tpo Kryo. You can create custom `TypeInfoFactory` for `List` and `Map`. There is no SetTypeInfo<T> though.
+* Some non-basic types like `java.time.Instant` serialize nicely without Kryo
+* Most of `java.time.*` types require Kryo
+* Nested POJO serialze without Kryo, as long as each component does not require Kryo
 
 
 ### Runtime configuration

--- a/java/Serialization/CustomTypeInfo/README.md
+++ b/java/Serialization/CustomTypeInfo/README.md
@@ -1,0 +1,105 @@
+## Using custom TypeInformation to avoid serialization falling back to Kryo
+
+This example shows how to define custom TypeInformation for your record objects to prevent Flink from falling back to 
+Kryo serialization.
+
+* Flink version: 1.20
+* Flink API: DataStream API
+* Language: Java (11)
+* Flink connectors: Kinesis Sink
+
+The application generates random data internally and, after an aggregation, writes the result to Kinesis.
+
+### Flink serialization
+
+This example illustrates how to define custom TypeInfo for the objects used internally in the application or stored in 
+the application state.
+
+#### Background
+
+Every object handed over between the operators of the application or stored in the application state is serialized using
+Flink serialization mechanism.
+
+Flink is able to efficiently serialize most of Java simple types, and POJOs where fields are basic types.
+
+When Flink cannot natively serialize an object, it falls back to using [Kryo](https://github.com/EsotericSoftware/kryo).
+Unfortunately, Kryo serialization is less efficient and has a considerable impact on performance. In particular on CPU
+utilization.
+
+One important case where Flink cannot natively serialize a field is with Collections. Due to Java type erasure, Flink 
+cannot discover the type of the elements of the collection, and falls back to Kryo to serialize it.
+
+#### Defining a TypeInfo
+
+To prevent this, you can explicitly define the type of the collection elements using the `@TypeInfo` annotation and 
+defining a custom `TypeInfoFactory`.
+This is demonstrated in these two record classes: 
+[`VehicleEvent`](src/main/java/com/amazonaws/services/msf/domain/VehicleEvent.java)
+and [`AgggregateVehicleEvent`](src/main/java/com/amazonaws/services/msf/domain/AggregateVehicleEvent.java)
+
+```java
+public class VehicleEvent {
+    //...
+    @TypeInfo(SensorDataTypeInfoFactory.class)
+    private Map<String, Long> sensorData = new HashMap<>();
+    //...
+    public static class SensorDataTypeInfoFactory extends TypeInfoFactory<Map<String, Long>> {
+        @Override
+        public TypeInformation<Map<String, Long>> createTypeInfo(Type t, Map<String, TypeInformation<?>> genericParameters) {
+            return new MapTypeInfo<>(Types.STRING, Types.LONG);
+        }
+    }
+}
+```
+
+For more details about Flink serialization, see [Data Types & Serialization](https://nightlies.apache.org/flink/flink-docs-release-1.20/docs/dev/datastream/fault-tolerance/serialization/types_serialization/#data-types--serialization)
+in Flink documentation.
+
+#### Testing serialization
+
+You can test that the serialization of your objects does not fall back to Kryo.
+
+You can use the `PojoTestUtils.assertSerializedAsPojoWithoutKryo(...)` method that is part of Flink test-utils 
+(`org.apache.flink:flink-test-utils` dependency).
+
+This assertion succeeds only if the serialization does NOT fall back to Kryo.
+
+However, if you make a mistake in the definition of `TypeInfoFactory`, the assertion above may succeed, but the actual
+serialization may fail or, even worse, have unpredictable results.
+
+To prevent this type of bugs, you can test that the serialization actually works.
+
+These tests are demonstrated in two unit tests: 
+[`VehicleEventSerializationTest`](src/test/java/com/amazonaws/services/msf/domain/VehicleEventSerializationTest.java)
+and [`AggregateVehicleEventSerializationTest`](src/test/java/com/amazonaws/services/msf/domain/AggregateVehicleEventSerializationTest.java).
+
+These tests use a test utility class that can be reused to test any record class:
+[`FlinkSerializationTestUtils`](src/test/java/com/amazonaws/services/msf/domain/FlinkSerializationTestUtils.java)
+
+
+
+### Runtime configuration
+
+When running on Amazon Managed Service for Apache Flink the runtime configuration is read from *Runtime Properties*.
+
+When running locally, the configuration is read from the [`resources/flink-application-properties-dev.json`](resources/flink-application-properties-dev.json) file located in the resources folder.
+
+Runtime parameters:
+
+| Group ID        | Key          | Description                                                                                                                                       | 
+|-----------------|--------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
+| `DataGen`       | `records.per.sec` | (optional) Number of generated records per second. Default = 100.
+| `OutputStream0` | `stream.name` | Name of the output stream                                                                                                                         |
+| `OutputStream0` | `aws.region` | Region of the output stream. If not specified, it will use the application region or the default region of the AWS profile, when running locally. |
+
+All parameters are case-sensitive.
+
+## Running locally in IntelliJ
+
+> Due to MSK VPC networking, to run this example on your machine you need to set up network connectivity to the VPC where MSK is deployed, for example with a VPN.
+> Setting this connectivity depends on your set up and is out of scope for this example.
+
+You can run this example directly in IntelliJ, without any local Flink cluster or local Flink installation.
+
+See [Running examples locally](../running-examples-locally.md) for details.
+

--- a/java/Serialization/CustomTypeInfo/README.md
+++ b/java/Serialization/CustomTypeInfo/README.md
@@ -86,11 +86,11 @@ When running locally, the configuration is read from the [`resources/flink-appli
 
 Runtime parameters:
 
-| Group ID        | Key          | Description                                                                                                                                       | 
-|-----------------|--------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
-| `DataGen`       | `records.per.sec` | (optional) Number of generated records per second. Default = 100.
-| `OutputStream0` | `stream.name` | Name of the output stream                                                                                                                         |
-| `OutputStream0` | `aws.region` | Region of the output stream. If not specified, it will use the application region or the default region of the AWS profile, when running locally. |
+| Group ID        | Key               | Description                                                                                                                                       | 
+|-----------------|-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
+| `DataGen`       | `records.per.sec` | (optional) Number of generated records per second. Default = 100.                                                                                 
+| `OutputStream0` | `stream.arn`      | ARN of the output stream                                                                                                                          |
+| `OutputStream0` | `aws.region`      | Region of the output stream. If not specified, it will use the application region or the default region of the AWS profile, when running locally. |
 
 All parameters are case-sensitive.
 

--- a/java/Serialization/CustomTypeInfo/pom.xml
+++ b/java/Serialization/CustomTypeInfo/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.amazonaws</groupId>
-    <artifactId>amazon-msf-windowing-app</artifactId>
+    <artifactId>custom-typeinfo</artifactId>
     <version>1.0</version>
     <packaging>jar</packaging>
 
@@ -20,21 +20,9 @@
         <aws.connector.version>4.3.0-1.19</aws.connector.version>
         <kda.runtime.version>1.2.0</kda.runtime.version>
         <log4j.version>2.23.1</log4j.version>
-        <jackson.version>2.17.0</jackson.version>
+        <junit5.version>5.8.1</junit5.version>
     </properties>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>com.amazonaws</groupId>
-                <artifactId>aws-java-sdk-bom</artifactId>
-                <!-- Get the latest SDK version from https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-bom -->
-                <version>1.12.677</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <dependencies>
         <!-- Apache Flink dependencies -->
@@ -69,6 +57,12 @@
         <!-- Connectors and Formats -->
         <dependency>
             <groupId>org.apache.flink</groupId>
+            <artifactId>flink-json</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
             <artifactId>flink-connector-datagen</artifactId>
             <version>${flink.version}</version>
         </dependency>
@@ -83,6 +77,7 @@
             <artifactId>flink-connector-kinesis</artifactId>
             <version>${aws.connector.version}</version>
         </dependency>
+
 
         <!-- Add logging framework, to produce console output when running in the IDE. -->
         <!-- These dependencies are excluded from the application JAR by default. -->
@@ -102,17 +97,28 @@
             <version>${log4j.version}</version>
         </dependency>
 
+        <!-- Tests -->
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit5.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit5.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-test-utils</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
-
     <build>
-        <directory>${buildDirectory}</directory>
-        <finalName>${jar.finalName}</finalName>
-
+        <finalName>${project.artifactId}-${flink.version}</finalName>
         <plugins>
             <!-- Java Compiler -->
             <plugin>
@@ -161,7 +167,7 @@
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                    <mainClass>com.amazonaws.services.msf.windowing.WindowStreamingJob</mainClass>
+                                    <mainClass>com.amazonaws.services.msf.CustomTypeInfoJob</mainClass>
                                 </transformer>
                             </transformers>
                         </configuration>

--- a/java/Serialization/CustomTypeInfo/src/main/java/com/amazonaws/services/msf/CustomTypeInfoJob.java
+++ b/java/Serialization/CustomTypeInfo/src/main/java/com/amazonaws/services/msf/CustomTypeInfoJob.java
@@ -56,9 +56,9 @@ public class CustomTypeInfoJob {
     }
 
     private static <T> KinesisStreamsSink<T> createKinesisSink(Properties kinesisClientProperties) {
-        String streamName = kinesisClientProperties.getProperty("stream.name", "ExampleOutputStream");
+        String streamArn = kinesisClientProperties.getProperty("stream.arn", "ExampleOutputStream");
         return KinesisStreamsSink.<T>builder()
-                .setStreamName(streamName)
+                .setStreamArn(streamArn)
                 .setSerializationSchema(new JsonSerializationSchema<>())
                 .setPartitionKeyGenerator(element -> String.valueOf(element.hashCode()))
                 .setKinesisClientProperties(kinesisClientProperties)

--- a/java/Serialization/CustomTypeInfo/src/main/java/com/amazonaws/services/msf/CustomTypeInfoJob.java
+++ b/java/Serialization/CustomTypeInfo/src/main/java/com/amazonaws/services/msf/CustomTypeInfoJob.java
@@ -1,0 +1,105 @@
+package com.amazonaws.services.msf;
+
+
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.connector.source.util.ratelimit.RateLimiterStrategy;
+import org.apache.flink.connector.datagen.source.DataGeneratorSource;
+import org.apache.flink.connector.kinesis.sink.KinesisStreamsSink;
+import org.apache.flink.formats.json.JsonSerializationSchema;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.LocalStreamEnvironment;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.windowing.assigners.TumblingProcessingTimeWindows;
+import org.apache.flink.util.PropertiesUtil;
+
+import com.amazonaws.services.kinesisanalytics.runtime.KinesisAnalyticsRuntime;
+import com.amazonaws.services.msf.datagen.VehicleEventGeneratorFunction;
+import com.amazonaws.services.msf.domain.AggregateVehicleEvent;
+import com.amazonaws.services.msf.domain.VehicleEvent;
+import com.amazonaws.services.msf.aggregation.AggregateVehicleEventsWindowFunction;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * Basic streaming job demonstrating how to define a custom TypeInfo for your records
+ */
+public class CustomTypeInfoJob {
+
+    private static final Logger LOGGER = LogManager.getLogger(CustomTypeInfoJob.class);
+
+    // Name of the local JSON resource with the application properties in the same format as they are received from the Amazon Managed Service for Apache Flink runtime
+    private static final String LOCAL_APPLICATION_PROPERTIES_RESOURCE = "flink-application-properties-dev.json";
+
+
+    private static boolean isLocal(StreamExecutionEnvironment env) {
+        return env instanceof LocalStreamEnvironment;
+    }
+
+    /**
+     * Load application properties from Amazon Managed Service for Apache Flink runtime or from a local resource, when the environment is local
+     */
+    private static Map<String, Properties> loadApplicationProperties(StreamExecutionEnvironment env) throws IOException {
+        if (isLocal(env)) {
+            LOGGER.info("Loading application properties from '{}'", LOCAL_APPLICATION_PROPERTIES_RESOURCE);
+            return KinesisAnalyticsRuntime.getApplicationProperties(CustomTypeInfoJob.class.getClassLoader()
+                    .getResource(LOCAL_APPLICATION_PROPERTIES_RESOURCE).getPath());
+        } else {
+            LOGGER.info("Loading application properties from Amazon Managed Service for Apache Flink");
+            return KinesisAnalyticsRuntime.getApplicationProperties();
+        }
+    }
+
+    private static <T> KinesisStreamsSink<T> createKinesisSink(Properties kinesisClientProperties) {
+        String streamName = kinesisClientProperties.getProperty("stream.name", "ExampleOutputStream");
+        return KinesisStreamsSink.<T>builder()
+                .setStreamName(streamName)
+                .setSerializationSchema(new JsonSerializationSchema<>())
+                .setPartitionKeyGenerator(element -> String.valueOf(element.hashCode()))
+                .setKinesisClientProperties(kinesisClientProperties)
+                .build();
+    }
+
+    public static void main(String[] args) throws Exception {
+        // Set up the streaming execution environment
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+        // Load application parameters
+        final Map<String, Properties> applicationParameters = loadApplicationProperties(env);
+
+        // Define the source
+        double recordsPerSecond = PropertiesUtil.getInt(applicationParameters.get("DataGen"), "records.per.sec", 100);
+        DataGeneratorSource<VehicleEvent> dataGenSource = new DataGeneratorSource<>(
+                new VehicleEventGeneratorFunction(),
+                Long.MAX_VALUE,
+                RateLimiterStrategy.perSecond(recordsPerSecond),
+                TypeInformation.of(VehicleEvent.class));
+
+        // Define the sink
+        KinesisStreamsSink<AggregateVehicleEvent> kinesisSink = createKinesisSink(applicationParameters.get("OutputStream0"));
+
+        /// Define the data flow
+
+        DataStream<AggregateVehicleEvent> aggregateEvents = env
+                // Data Generator Source
+                .fromSource(dataGenSource, WatermarkStrategy.noWatermarks(), "Data Generator").uid("datagen")
+                // Aggregate over 10 second windows
+                .keyBy(VehicleEvent::getVin)
+                .window(TumblingProcessingTimeWindows.of(Duration.ofSeconds(10)))
+                // The ProcessWindowFunction will save the received records in Flink state
+                .process(new AggregateVehicleEventsWindowFunction()).returns(AggregateVehicleEvent.class).uid("aggregation");
+
+        // aggregateEvents.print();
+
+        // Sink to Kinesis
+        aggregateEvents.sinkTo(kinesisSink).uid("kinesis-sink");
+
+        env.execute("Custom TypeInfo job");
+    }
+
+}

--- a/java/Serialization/CustomTypeInfo/src/main/java/com/amazonaws/services/msf/aggregation/AggregateVehicleEventsWindowFunction.java
+++ b/java/Serialization/CustomTypeInfo/src/main/java/com/amazonaws/services/msf/aggregation/AggregateVehicleEventsWindowFunction.java
@@ -1,0 +1,51 @@
+package com.amazonaws.services.msf.aggregation;
+
+import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
+import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
+import org.apache.flink.util.Collector;
+
+import com.amazonaws.services.msf.domain.AggregateVehicleEvent;
+import com.amazonaws.services.msf.domain.VehicleEvent;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Implementation of ProcessWindowFunction that aggregates the sensor data and warning lights for a vehicle.
+ * <p>
+ * The actual implementation is not relevant for this example.
+ */
+public class AggregateVehicleEventsWindowFunction extends ProcessWindowFunction<VehicleEvent, AggregateVehicleEvent, String, TimeWindow> {
+    @Override
+    public void process(String vin, ProcessWindowFunction<VehicleEvent, AggregateVehicleEvent, String, TimeWindow>.Context context, Iterable<VehicleEvent> events, Collector<AggregateVehicleEvent> out) throws Exception {
+        Map<String, Long> sensorTotal = new HashMap<>();
+        Set<String> warnings = new HashSet<>();
+        long count = 0;
+        for (VehicleEvent event : events) {
+            // Average of sensor data
+            for (Map.Entry<String, Long> sensorMeasurement : event.getSensorData().entrySet()) {
+                String sensorId = sensorMeasurement.getKey();
+                long newSensorData = sensorMeasurement.getValue();
+                sensorTotal.merge(sensorId, newSensorData, Long::sum);
+            }
+            // Unique warnings
+            warnings.addAll(event.getWarningLights());
+
+            count++;
+        }
+
+        final long sensorDataCount = count;
+        Map<String, Long> sensorAverage = sensorTotal.entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue() / sensorDataCount));
+
+        out.collect(new AggregateVehicleEvent(
+                vin,
+                context.window().maxTimestamp(),
+                sensorAverage,
+                warnings.size()
+        ));
+    }
+}

--- a/java/Serialization/CustomTypeInfo/src/main/java/com/amazonaws/services/msf/datagen/VehicleEventGeneratorFunction.java
+++ b/java/Serialization/CustomTypeInfo/src/main/java/com/amazonaws/services/msf/datagen/VehicleEventGeneratorFunction.java
@@ -5,7 +5,7 @@ import org.apache.flink.connector.datagen.source.GeneratorFunction;
 import com.amazonaws.services.msf.domain.VehicleEvent;
 import org.apache.commons.lang3.RandomUtils;
 
-import java.util.List;
+import java.util.ArrayList;
 import java.util.Map;
 
 /**
@@ -20,12 +20,14 @@ public class VehicleEventGeneratorFunction implements GeneratorFunction<Long, Ve
         return new VehicleEvent(
                 String.format("V%08d", RandomUtils.nextInt(0, 100)),
                 System.currentTimeMillis(),
-                Map.of(
-                        "speed", RandomUtils.nextLong(0, 120),
-                        "rpm", RandomUtils.nextLong(1000, 10000),
-                        "fuelLevel", RandomUtils.nextLong(0, 100)
+                Map.ofEntries(
+                        Map.entry("speed", RandomUtils.nextLong(0, 120)),
+                        Map.entry("rpm", RandomUtils.nextLong(1000, 10000)),
+                        Map.entry("fuelLevel", RandomUtils.nextLong(0, 100))
                 ),
-                List.of(WARNING_LIGHTS[RandomUtils.nextInt(0, WARNING_LIGHTS.length)])
+                new ArrayList<String>() {{
+                    add(WARNING_LIGHTS[RandomUtils.nextInt(0, WARNING_LIGHTS.length)]);
+                }}
         );
     }
 }

--- a/java/Serialization/CustomTypeInfo/src/main/java/com/amazonaws/services/msf/datagen/VehicleEventGeneratorFunction.java
+++ b/java/Serialization/CustomTypeInfo/src/main/java/com/amazonaws/services/msf/datagen/VehicleEventGeneratorFunction.java
@@ -6,7 +6,7 @@ import com.amazonaws.services.msf.domain.VehicleEvent;
 import org.apache.commons.lang3.RandomUtils;
 
 import java.util.ArrayList;
-import java.util.Map;
+import java.util.HashMap;
 
 /**
  * Implementation of GeneratorFunction that generates random {@link VehicleEvent}
@@ -16,16 +16,16 @@ public class VehicleEventGeneratorFunction implements GeneratorFunction<Long, Ve
     private static final String[] WARNING_LIGHTS = {"fuelPressure", "oilPressure", "tirePressure"};
 
     @Override
-    public VehicleEvent map(Long value) throws Exception {
+    public VehicleEvent map(Long value) {
         return new VehicleEvent(
                 String.format("V%08d", RandomUtils.nextInt(0, 100)),
                 System.currentTimeMillis(),
-                Map.ofEntries(
-                        Map.entry("speed", RandomUtils.nextLong(0, 120)),
-                        Map.entry("rpm", RandomUtils.nextLong(1000, 10000)),
-                        Map.entry("fuelLevel", RandomUtils.nextLong(0, 100))
-                ),
-                new ArrayList<String>() {{
+                new HashMap<>() {{
+                    put("speed", RandomUtils.nextLong(0, 120));
+                    put("rpm", RandomUtils.nextLong(1000, 10000));
+                    put("fuelLevel", RandomUtils.nextLong(0, 100));
+                }},
+                new ArrayList<>() {{
                     add(WARNING_LIGHTS[RandomUtils.nextInt(0, WARNING_LIGHTS.length)]);
                 }}
         );

--- a/java/Serialization/CustomTypeInfo/src/main/java/com/amazonaws/services/msf/datagen/VehicleEventGeneratorFunction.java
+++ b/java/Serialization/CustomTypeInfo/src/main/java/com/amazonaws/services/msf/datagen/VehicleEventGeneratorFunction.java
@@ -1,0 +1,31 @@
+package com.amazonaws.services.msf.datagen;
+
+import org.apache.flink.connector.datagen.source.GeneratorFunction;
+
+import com.amazonaws.services.msf.domain.VehicleEvent;
+import org.apache.commons.lang3.RandomUtils;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Implementation of GeneratorFunction that generates random {@link VehicleEvent}
+ */
+public class VehicleEventGeneratorFunction implements GeneratorFunction<Long, VehicleEvent> {
+
+    private static final String[] WARNING_LIGHTS = {"fuelPressure", "oilPressure", "tirePressure"};
+
+    @Override
+    public VehicleEvent map(Long value) throws Exception {
+        return new VehicleEvent(
+                String.format("V%08d", RandomUtils.nextInt(0, 100)),
+                System.currentTimeMillis(),
+                Map.of(
+                        "speed", RandomUtils.nextLong(0, 120),
+                        "rpm", RandomUtils.nextLong(1000, 10000),
+                        "fuelLevel", RandomUtils.nextLong(0, 100)
+                ),
+                List.of(WARNING_LIGHTS[RandomUtils.nextInt(0, WARNING_LIGHTS.length)])
+        );
+    }
+}

--- a/java/Serialization/CustomTypeInfo/src/main/java/com/amazonaws/services/msf/domain/AggregateVehicleEvent.java
+++ b/java/Serialization/CustomTypeInfo/src/main/java/com/amazonaws/services/msf/domain/AggregateVehicleEvent.java
@@ -1,0 +1,109 @@
+package com.amazonaws.services.msf.domain;
+
+import org.apache.flink.api.common.typeinfo.TypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInfoFactory;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.typeutils.MapTypeInfo;
+
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Record representing aggregate events from connected vehicle.
+ * <p>
+ * Similarly to {@link VehicleEvent}, it demonstrates the use of custom TypeInformation.
+ */
+public class AggregateVehicleEvent {
+    private String vin;
+    private long timestamp;
+
+    @TypeInfo(AverageSensorDataTypeInfoFactory.class)
+    private Map<String, Long> averageSensorData = new HashMap<>();
+
+    private int countDistinctWarnings;
+
+
+    /// Custom TypeInformation factory
+
+    public static class AverageSensorDataTypeInfoFactory extends TypeInfoFactory<Map<String, Long>> {
+        @Override
+        public TypeInformation<Map<String, Long>> createTypeInfo(Type t, Map<String, TypeInformation<?>> genericParameters) {
+            return new MapTypeInfo<>(Types.STRING, Types.LONG);
+        }
+    }
+
+    /// Constructors and accessors
+
+
+    public AggregateVehicleEvent() {
+    }
+
+    public AggregateVehicleEvent(String vin, long timestamp, Map<String, Long> averageSensorData, int countDistinctWarnings) {
+        this.vin = vin;
+        this.timestamp = timestamp;
+        this.averageSensorData = averageSensorData;
+        this.countDistinctWarnings = countDistinctWarnings;
+    }
+
+    public String getVin() {
+        return vin;
+    }
+
+    public void setVin(String vin) {
+        this.vin = vin;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(long timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public Map<String, Long> getAverageSensorData() {
+        return averageSensorData;
+    }
+
+    public void setAverageSensorData(Map<String, Long> averageSensorData) {
+        this.averageSensorData = averageSensorData;
+    }
+
+    public int getCountDistinctWarnings() {
+        return countDistinctWarnings;
+    }
+
+    public void setCountDistinctWarnings(int countDistinctWarnings) {
+        this.countDistinctWarnings = countDistinctWarnings;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AggregateVehicleEvent that = (AggregateVehicleEvent) o;
+        return timestamp == that.timestamp && countDistinctWarnings == that.countDistinctWarnings && Objects.equals(vin, that.vin) && Objects.equals(averageSensorData, that.averageSensorData);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(vin, timestamp, averageSensorData, countDistinctWarnings);
+    }
+
+    @Override
+    public String toString() {
+        return "AggregateVehicleEvent{" +
+                "vin='" + vin + '\'' +
+                ", timestamp=" + timestamp +
+                ", averageSensorData=" + averageSensorData +
+                ", countDistinctWarnings=" + countDistinctWarnings +
+                '}';
+    }
+}

--- a/java/Serialization/CustomTypeInfo/src/main/java/com/amazonaws/services/msf/domain/VehicleEvent.java
+++ b/java/Serialization/CustomTypeInfo/src/main/java/com/amazonaws/services/msf/domain/VehicleEvent.java
@@ -1,0 +1,144 @@
+package com.amazonaws.services.msf.domain;
+
+import org.apache.flink.api.common.typeinfo.TypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInfoFactory;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.typeutils.ListTypeInfo;
+import org.apache.flink.api.java.typeutils.MapTypeInfo;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Record representing an event sent by a connected vehicle.
+ * The object follows POJO standards.
+ * <p>
+ * What's relevant to this example is that the object also contains a Map property and a List property.
+ * <p>
+ * This class demonstrates two alternative methods fir defining custom TypeInformation:
+ * 1. Defining a TypeInfoFactory for each field that requires type information, in
+ * 2. Defining a single TypeInfoFactory for the entire POJO class (commented out)
+ */
+// @TypeInfo(VehicleEvent.VehicleEventTypeInfoFactory.class)
+public class VehicleEvent {
+    private String vin;
+    private long timestamp;
+
+    @TypeInfo(SensorDataTypeInfoFactory.class)
+    private Map<String, Long> sensorData = new HashMap<>();
+
+    @TypeInfo(WariningLightsTypeInfoFactory.class)
+    private List<String> warningLights = new ArrayList<>();
+
+    /// Custom TypeInformation factories
+
+    public static class SensorDataTypeInfoFactory extends TypeInfoFactory<Map<String, Long>> {
+        @Override
+        public TypeInformation<Map<String, Long>> createTypeInfo(Type t, Map<String, TypeInformation<?>> genericParameters) {
+            return new MapTypeInfo<>(Types.STRING, Types.LONG);
+        }
+    }
+
+    ;
+
+    public static class WariningLightsTypeInfoFactory extends TypeInfoFactory<List<String>> {
+        @Override
+        public TypeInformation<List<String>> createTypeInfo(Type t, Map<String, TypeInformation<?>> genericParameters) {
+            return new ListTypeInfo<>(Types.STRING);
+        }
+    }
+
+    // As an alternative, you can define a single TypeInfoFactory for the whole POJO.
+    // This requires setting the @TypeInfo at class level.
+    // The two methods are alternative and mutually exclusive.
+//    public static class VehicleEventTypeInfoFactory extends TypeInfoFactory<VehicleEvent> {
+//        @Override
+//        public TypeInformation<VehicleEvent> createTypeInfo(Type t, Map<String, TypeInformation<?>> genericParameters) {
+//            return Types.POJO(
+//                    VehicleEvent.class,
+//                    Map.of(
+//                            "vin", Types.STRING,
+//                            "timestamp", Types.LONG,
+//                            "sensorData", new MapTypeInfo<>(Types.STRING, Types.LONG),
+//                            "warningLights", new ListTypeInfo<>(Types.STRING)
+//                    ));
+//        }
+//    }
+
+
+    /// Constructors and accessors
+
+    public VehicleEvent() {
+    }
+
+    public VehicleEvent(String vin, long timestamp, Map<String, Long> sensorData, List<String> warningLights) {
+        this.vin = vin;
+        this.timestamp = timestamp;
+        this.sensorData = sensorData;
+        this.warningLights = warningLights;
+    }
+
+    public String getVin() {
+        return vin;
+    }
+
+    public void setVin(String vin) {
+        this.vin = vin;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(long timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public Map<String, Long> getSensorData() {
+        return sensorData;
+    }
+
+    public void setSensorData(Map<String, Long> sensorData) {
+        this.sensorData = sensorData;
+    }
+
+    public List<String> getWarningLights() {
+        return warningLights;
+    }
+
+    public void setWarningLights(List<String> warningLights) {
+        this.warningLights = warningLights;
+    }
+
+    @Override
+    public String toString() {
+        return "VehicleEvent{" +
+                "vin='" + vin + '\'' +
+                ", timestamp=" + timestamp +
+                ", sensorData=" + sensorData +
+                ", warningLights=" + warningLights +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        VehicleEvent that = (VehicleEvent) o;
+        return timestamp == that.timestamp && Objects.equals(vin, that.vin) && Objects.equals(sensorData, that.sensorData) && Objects.equals(warningLights, that.warningLights);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(vin, timestamp, sensorData, warningLights);
+    }
+}

--- a/java/Serialization/CustomTypeInfo/src/main/resources/flink-application-properties-dev.json
+++ b/java/Serialization/CustomTypeInfo/src/main/resources/flink-application-properties-dev.json
@@ -9,7 +9,7 @@
     "PropertyGroupId": "OutputStream0",
     "PropertyMap": {
       "aws.region": "us-east-1",
-      "stream.name": "ExampleOutputStream"
+      "stream.arn": "arn:aws:kinesis:us-east-1:<account>:stream/<stream-name>"
     }
   }
 ]

--- a/java/Serialization/CustomTypeInfo/src/main/resources/flink-application-properties-dev.json
+++ b/java/Serialization/CustomTypeInfo/src/main/resources/flink-application-properties-dev.json
@@ -1,0 +1,15 @@
+[
+  {
+    "PropertyGroupId": "DataGen",
+    "PropertyMap": {
+      "records.per.sec": "10"
+    }
+  },
+  {
+    "PropertyGroupId": "OutputStream0",
+    "PropertyMap": {
+      "aws.region": "us-east-1",
+      "stream.name": "ExampleOutputStream"
+    }
+  }
+]

--- a/java/Serialization/CustomTypeInfo/src/main/resources/log4j2.properties
+++ b/java/Serialization/CustomTypeInfo/src/main/resources/log4j2.properties
@@ -1,0 +1,12 @@
+rootLogger.level = INFO
+rootLogger.appenderRef.console.ref = ConsoleAppender
+
+#logger.tracing.name = com.amazonaws.services.msf
+#logger.tracing.level = TRACE
+#logger.tracing.additivity = false
+#logger.tracing.appenderRef.console.ref = ConsoleAppender
+
+appender.console.name = ConsoleAppender
+appender.console.type = CONSOLE
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{HH:mm:ss,SSS} %-5p %-60c %x - %m%n

--- a/java/Serialization/CustomTypeInfo/src/test/java/com/amazonaws/services/msf/domain/AggregateVehicleEventSerializationTest.java
+++ b/java/Serialization/CustomTypeInfo/src/test/java/com/amazonaws/services/msf/domain/AggregateVehicleEventSerializationTest.java
@@ -34,10 +34,10 @@ public class AggregateVehicleEventSerializationTest {
         AggregateVehicleEvent record = new AggregateVehicleEvent(
                 "V123456X"
                 , 42L,
-                Map.of(
-                        "speed", 100L,
-                        "rpm", 2000L,
-                        "fuelLevel", 12345L
+                Map.ofEntries(
+                        Map.entry("speed", 100L),
+                        Map.entry("rpm", 2000L),
+                        Map.entry("fuelLevel", 12345L)
                 ),
                 42);
 

--- a/java/Serialization/CustomTypeInfo/src/test/java/com/amazonaws/services/msf/domain/AggregateVehicleEventSerializationTest.java
+++ b/java/Serialization/CustomTypeInfo/src/test/java/com/amazonaws/services/msf/domain/AggregateVehicleEventSerializationTest.java
@@ -21,10 +21,10 @@ public class AggregateVehicleEventSerializationTest {
         // It does not test whether the serialization/deserialization actually work
         // If you make a mistake defining the TypeInfo for the class, this test will succeed
         // but the serialization may still fail or give unexpected results.
+        PojoTestUtils.assertSerializedAsPojoWithoutKryo(AggregateVehicleEvent.class);
 
         // This test is redundant if you implement the other test, below.
 
-        PojoTestUtils.assertSerializedAsPojoWithoutKryo(AggregateVehicleEvent.class);
     }
 
     @Test

--- a/java/Serialization/CustomTypeInfo/src/test/java/com/amazonaws/services/msf/domain/AggregateVehicleEventSerializationTest.java
+++ b/java/Serialization/CustomTypeInfo/src/test/java/com/amazonaws/services/msf/domain/AggregateVehicleEventSerializationTest.java
@@ -1,0 +1,56 @@
+package com.amazonaws.services.msf.domain;
+
+import org.apache.flink.types.PojoTestUtils;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests the serialization of {@link AggregateVehicleEvent}
+ */
+public class AggregateVehicleEventSerializationTest {
+
+    @Test
+    void serializationShouldNotFallbackToKryo() {
+        // This Flink test-utils method verifies that serialization does not fall back to Kryo
+        // It does not test whether the serialization/deserialization actually work
+        // If you make a mistake defining the TypeInfo for the class, this test will succeed
+        // but the serialization may still fail or give unexpected results.
+
+        // This test is redundant if you implement the other test, below.
+
+        PojoTestUtils.assertSerializedAsPojoWithoutKryo(AggregateVehicleEvent.class);
+    }
+
+    @Test
+    void shouldSerializeAndDeserializeWithoutKryo() throws IOException {
+        // This test is an extension of the previous test. It actually serializes and deserializes the record
+        // and verifies that the content was correctly serialized/deserialized
+        // If you make a mistake defining the TypeInfo for the class, this test will fail
+        AggregateVehicleEvent record = new AggregateVehicleEvent(
+                "V123456X"
+                , 42L,
+                Map.of(
+                        "speed", 100L,
+                        "rpm", 2000L,
+                        "fuelLevel", 12345L
+                ),
+                42);
+
+
+        // Serialize and deserialize the record forcing Kryo
+        // This will fail if Flink has to fallback to Kryo
+        AggregateVehicleEvent deserialized = FlinkSerializationTestUtils.serializeDeserializeNoKryo(record, AggregateVehicleEvent.class);
+
+        // Compare the original record with the deserialized record
+        // If you made a mistake in defining the TypeInfo, this comparison will fail
+        assertEquals(record.getVin(), deserialized.getVin());
+        assertEquals(record.getTimestamp(), deserialized.getTimestamp());
+        assertEquals(record.getAverageSensorData(), deserialized.getAverageSensorData());
+        assertEquals(record.getCountDistinctWarnings(), deserialized.getCountDistinctWarnings());
+    }
+}

--- a/java/Serialization/CustomTypeInfo/src/test/java/com/amazonaws/services/msf/domain/AggregateVehicleEventSerializationTest.java
+++ b/java/Serialization/CustomTypeInfo/src/test/java/com/amazonaws/services/msf/domain/AggregateVehicleEventSerializationTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.util.Map;
 
+import static java.util.Map.entry;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
@@ -35,9 +36,9 @@ public class AggregateVehicleEventSerializationTest {
                 "V123456X"
                 , 42L,
                 Map.ofEntries(
-                        Map.entry("speed", 100L),
-                        Map.entry("rpm", 2000L),
-                        Map.entry("fuelLevel", 12345L)
+                        entry("speed", 100L),
+                        entry("rpm", 2000L),
+                        entry("fuelLevel", 12345L)
                 ),
                 42);
 

--- a/java/Serialization/CustomTypeInfo/src/test/java/com/amazonaws/services/msf/domain/FlinkSerializationTestUtils.java
+++ b/java/Serialization/CustomTypeInfo/src/test/java/com/amazonaws/services/msf/domain/FlinkSerializationTestUtils.java
@@ -1,0 +1,72 @@
+package com.amazonaws.services.msf.domain;
+
+import org.apache.flink.api.common.serialization.SerializerConfig;
+import org.apache.flink.api.common.serialization.SerializerConfigImpl;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataInputViewStreamWrapper;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+
+import java.io.IOException;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+
+/**
+ * Utilities for testing Flink serialization.
+ */
+public class FlinkSerializationTestUtils {
+
+    /**
+     * Round-trip serialization-deserialization of a record, using Flink serializers.
+     * Returns the deserialized record por fails, if Flink cannot serialize/deserialize based on the available TypeInfo
+     * and serializer configuration.
+     *
+     * @param record           The record to serialize
+     * @param clazz            The class of the record
+     * @param serializerConfig The serializer configuration
+     * @param <T>              The type of the record
+     * @return The deserialized record
+     * @throws IOException If an I/O error occurs during serialization or deserialization
+     */
+    public static <T> T serializeDeserialize(T record, Class<T> clazz, SerializerConfig serializerConfig) throws IOException {
+
+        TypeInformation<T> typeInfo = TypeInformation.of(clazz);
+        TypeSerializer<T> serializer = typeInfo.createSerializer(serializerConfig);
+
+        PipedInputStream deserializerIn = new PipedInputStream();
+        PipedOutputStream serializerOut = new PipedOutputStream(deserializerIn);
+
+        // Serialize
+        DataOutputView serializerOutput = new DataOutputViewStreamWrapper(serializerOut);
+        serializer.serialize(record, serializerOutput);
+
+        // Deserialize
+        DataInputView deserializerInput = new DataInputViewStreamWrapper(deserializerIn);
+        return serializer.deserialize(deserializerInput);
+    }
+
+    /**
+     * Round-trip serialization-deserialization of a record, using Flink serializers, disabling "generic types",
+     * i.e. disabling Kryo fallback.
+     * The serialization will fail if Flink has to fallback to Kryo.
+     * <p>
+     * This method does more than PojoTestUtils.assertSerializedAsPojo(...) because it actually serialize and deserialize
+     * the record, so you can verify that the content was correctly serialized/deserialized.
+     * PojoTestUtils.assertSerializedAsPojo(...) only verifies that serialization does not fall-back to Kryo. However,
+     * if you created an incorrect TypeInfo for the class, the serialization may succeed but missing some of the fields.
+     *
+     * @param record The record to serialize
+     * @param clazz  The class of the record
+     * @param <T>    The type of the record
+     * @return The deserialized record
+     * @throws IOException If an I/O error occurs during serialization or deserialization
+     */
+    public static <T> T serializeDeserializeNoKryo(T record, Class<T> clazz) throws IOException {
+        SerializerConfig serializerConfig = new SerializerConfigImpl();
+        serializerConfig.setGenericTypes(false); // Disable Kryo generic types
+        return serializeDeserialize(record, clazz, new SerializerConfigImpl());
+    }
+
+}

--- a/java/Serialization/CustomTypeInfo/src/test/java/com/amazonaws/services/msf/domain/MoreKryoSerializationExamplesTest.java
+++ b/java/Serialization/CustomTypeInfo/src/test/java/com/amazonaws/services/msf/domain/MoreKryoSerializationExamplesTest.java
@@ -1,0 +1,233 @@
+package com.amazonaws.services.msf.domain;
+
+import org.apache.flink.api.common.typeinfo.TypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInfoFactory;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.types.PojoTestUtils;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * This test collects different examples of record object that will or will not fall-back to Kryo for serialization.
+ * <p>
+ * Serialization tests are included for all examples. Those tests that are supposed to fail are disabled.
+ * Remove the @Disabled annotation to observe them actually failing.
+ * <p>
+ * Refer Data Types & Serialization in Flink documentation for further details
+ * https://nightlies.apache.org/flink/flink-docs-release-1.20/docs/dev/datastream/fault-tolerance/serialization/types_serialization/#data-types--serialization
+ */
+public class MoreKryoSerializationExamplesTest {
+
+    /**
+     * This POJO contains a Collection field.
+     * It falls back to Kryo unless you add a @TypeInfo
+     */
+    public static class PojoWithCollection {
+        private List<String> elements = new ArrayList<>();
+        private Map<String, Integer> mapOfElements = new HashMap<>();
+
+        // Flink does not have a org.apache.flink.api.java.typeutils.SetTypeInfo<T>.
+        // You cannot easily define a TypeInfoFactory for a Set
+        private Set<String> setOfElements = new HashSet<>();
+
+        public List<String> getElements() {
+            return elements;
+        }
+
+        public void setElements(List<String> elements) {
+            this.elements = elements;
+        }
+
+        public Map<String, Integer> getMapOfElements() {
+            return mapOfElements;
+        }
+
+        public void setMapOfElements(Map<String, Integer> mapOfElements) {
+            this.mapOfElements = mapOfElements;
+        }
+
+        public Set<String> getSetOfElements() {
+            return setOfElements;
+        }
+
+        public void setSetOfElements(Set<String> setOfElements) {
+            this.setOfElements = setOfElements;
+        }
+    }
+
+    // THIS TEST IS SUPPOSED TO FAIL
+    @Test
+    @Disabled
+    void pojoWithCollectionShouldNotFallbackToKryo() {
+        PojoTestUtils.assertSerializedAsPojoWithoutKryo(PojoWithCollection.class);
+    }
+
+
+    //---------------------------------------------------------------------
+
+    /// Not all non-basic types fall back to Kryo.
+    /// For example, java.time.Instant serializes nicely
+
+    // POJO containing a java.time.Instant field
+    public static class PojoWithInstant {
+        private Instant timestamp;
+
+        public Instant getTimestamp() {
+            return timestamp;
+        }
+
+        public void setTimestamp(Instant timestamp) {
+            this.timestamp = timestamp;
+        }
+    }
+
+    // Serialization of Instant field does not fall back Kryo
+    @Test
+    void pojoWithInstantShouldNotFallbackToKryo() {
+        PojoTestUtils.assertSerializedAsPojoWithoutKryo(PojoWithInstant.class);
+    }
+
+    // Serialization of Instant field works correctly
+    @Test
+    void pojoWithInstantShouldSerializeAndDeserializeWithoutKryo() throws IOException {
+        PojoWithInstant record = new PojoWithInstant();
+        record.setTimestamp(Instant.now());
+
+        PojoWithInstant deserialized = FlinkSerializationTestUtils.serializeDeserializeNoKryo(record, PojoWithInstant.class);
+
+        assertEquals(record.getTimestamp(), deserialized.getTimestamp());
+    }
+
+    //---------------------------------------------------------------------
+
+    /// Not all java.time classes serialize without Kryo.
+    /// ZonedDateTime and Duration, for example, require falliing back to Kryo
+
+    // Pojo with a java.time.ZonedDateTime, java.time.LocalDateTime, and java.time.Duration
+    public static class PojoWithNonDirectlySerializableTimeFields {
+        private ZonedDateTime zonedDateTime;
+        private Duration duration;
+        private LocalDateTime localDateTime;
+
+        public ZonedDateTime getZonedDateTime() {
+            return zonedDateTime;
+        }
+
+        public void setZonedDateTime(ZonedDateTime zonedDateTime) {
+            this.zonedDateTime = zonedDateTime;
+        }
+
+        public Duration getDuration() {
+            return duration;
+        }
+
+        public void setDuration(Duration duration) {
+            this.duration = duration;
+        }
+
+
+        public LocalDateTime getLocalDateTime() {
+            return localDateTime;
+        }
+
+        public void setLocalDateTime(LocalDateTime localDateTime) {
+            this.localDateTime = localDateTime;
+        }
+    }
+
+
+    // THIS TEST WILL FAIL
+    @Test
+    @Disabled
+    void pojoWithZonedDateTimeShouldNotFallbackToKryo() {
+        PojoTestUtils.assertSerializedAsPojoWithoutKryo(PojoWithNonDirectlySerializableTimeFields.class);
+    }
+
+
+    //---------------------------------------------------------------------
+
+    /// Nested POJOs have no issue being serialized without Kryo,
+    /// as long as all components are individually serializable without Kryo.
+
+    public static class NestedPojo {
+        String name;
+        Address address;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public Address getAddress() {
+            return address;
+        }
+
+        public void setAddress(Address address) {
+            this.address = address;
+        }
+    }
+
+    public static class Address {
+        private String street;
+        private String postCode;
+
+        public String getStreet() {
+            return street;
+        }
+
+        public void setStreet(String street) {
+            this.street = street;
+        }
+
+        public String getPostCode() {
+            return postCode;
+        }
+
+        public void setPostCode(String postCode) {
+            this.postCode = postCode;
+        }
+    }
+
+    // Nested POJO serialization does not fall-back to Kryo
+    @Test
+    void nestedPojosShouldNotFallbackToKryo() {
+        PojoTestUtils.assertSerializedAsPojoWithoutKryo(NestedPojo.class);
+    }
+
+
+    // Nested POJOs serialize and deserialize nicely
+    @Test
+    void nestedPojoSerializeAndDeserializeWithoutKryo() throws IOException {
+        NestedPojo record = new NestedPojo();
+        record.setName("My Name");
+        Address address = new Address();
+        address.setStreet("Long Str");
+        address.setPostCode("XYZ123");
+        record.setAddress(address);
+
+        NestedPojo deserialized = FlinkSerializationTestUtils.serializeDeserializeNoKryo(record, NestedPojo.class);
+
+        assertEquals(record.getName(), deserialized.getName());
+        assertEquals(record.getAddress().getPostCode(), deserialized.getAddress().getPostCode());
+        assertEquals(record.getAddress().getStreet(), deserialized.getAddress().getStreet());
+    }
+}

--- a/java/Serialization/CustomTypeInfo/src/test/java/com/amazonaws/services/msf/domain/VehicleEventSerializationTest.java
+++ b/java/Serialization/CustomTypeInfo/src/test/java/com/amazonaws/services/msf/domain/VehicleEventSerializationTest.java
@@ -5,9 +5,10 @@ import org.apache.flink.types.PojoTestUtils;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
+import static java.util.Map.entry;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
@@ -36,14 +37,14 @@ public class VehicleEventSerializationTest {
                 "V123456X"
                 , 42L,
                 Map.ofEntries(
-                        Map.entry("speed", 100L),
-                        Map.entry("rpm", 2000L),
-                        Map.entry("fuelLevel", 12345L)
+                        entry("speed", 100L),
+                        entry("rpm", 2000L),
+                        entry("fuelLevel", 12345L)
                 ),
-                new ArrayList<String>() {{
-                    add("OIL_TEMPERATURE");
-                    add("TIRE_PRESSURE");
-                }}
+                List.of(
+                        "OIL_TEMPERATURE",
+                        "TIRE_PRESSURE"
+                )
         );
 
         // Serialize and deserialize the record forcing Kryo

--- a/java/Serialization/CustomTypeInfo/src/test/java/com/amazonaws/services/msf/domain/VehicleEventSerializationTest.java
+++ b/java/Serialization/CustomTypeInfo/src/test/java/com/amazonaws/services/msf/domain/VehicleEventSerializationTest.java
@@ -22,10 +22,9 @@ public class VehicleEventSerializationTest {
         // It does not test whether the serialization/deserialization actually work
         // If you make a mistake defining the TypeInfo for the class, this test will succeed
         // but the serialization may still fail or give unexpected results.
+        PojoTestUtils.assertSerializedAsPojoWithoutKryo(VehicleEvent.class);
 
         // This test is redundant if you implement the other test, below.
-
-        PojoTestUtils.assertSerializedAsPojoWithoutKryo(VehicleEvent.class);
     }
 
     @Test

--- a/java/Serialization/CustomTypeInfo/src/test/java/com/amazonaws/services/msf/domain/VehicleEventSerializationTest.java
+++ b/java/Serialization/CustomTypeInfo/src/test/java/com/amazonaws/services/msf/domain/VehicleEventSerializationTest.java
@@ -1,0 +1,58 @@
+package com.amazonaws.services.msf.domain;
+
+import org.apache.flink.types.PojoTestUtils;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests the serialization of {@link VehicleEvent}
+ */
+public class VehicleEventSerializationTest {
+
+    @Test
+    void serializationShouldNotFallbackToKryo() {
+        // This Flink test-utils method verifies that serialization does not fall back to Kryo
+        // It does not test whether the serialization/deserialization actually work
+        // If you make a mistake defining the TypeInfo for the class, this test will succeed
+        // but the serialization may still fail or give unexpected results.
+
+        // This test is redundant if you implement the other test, below.
+
+        PojoTestUtils.assertSerializedAsPojoWithoutKryo(VehicleEvent.class);
+    }
+
+    @Test
+    void shouldSerializeAndDeserializeWithoutKryo() throws IOException {
+        // This test is an extension of the previous test. It actually serializes and deserializes the record
+        // and verifies that the content was correctly serialized/deserialized
+        // If you make a mistake defining the TypeInfo for the class, this test will fail
+        VehicleEvent record = new VehicleEvent(
+                "V123456X"
+                , 42L,
+                Map.of(
+                        "speed", 100L,
+                        "rpm", 2000L,
+                        "fuelLevel", 12345L
+                ),
+                List.of("OIL_TEMPERATURE", "TIRE_PRESSURE")
+        );
+
+        // Serialize and deserialize the record forcing Kryo
+        // This will fail if Flink has to fallback to Kryo
+        VehicleEvent deserialized =  FlinkSerializationTestUtils.serializeDeserializeNoKryo(record, VehicleEvent.class);
+
+        // Compare the original record with the deserialized record
+        // If you made a mistake in defining the TypeInfo, this comparison will fail
+        assertEquals(record.getVin(), deserialized.getVin());
+        assertEquals(record.getTimestamp(), deserialized.getTimestamp());
+        assertEquals(record.getSensorData(), deserialized.getSensorData());
+        assertEquals(record.getWarningLights(), deserialized.getWarningLights());
+
+    }
+}

--- a/java/Serialization/CustomTypeInfo/src/test/java/com/amazonaws/services/msf/domain/VehicleEventSerializationTest.java
+++ b/java/Serialization/CustomTypeInfo/src/test/java/com/amazonaws/services/msf/domain/VehicleEventSerializationTest.java
@@ -5,7 +5,7 @@ import org.apache.flink.types.PojoTestUtils;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.util.List;
+import java.util.ArrayList;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -35,17 +35,20 @@ public class VehicleEventSerializationTest {
         VehicleEvent record = new VehicleEvent(
                 "V123456X"
                 , 42L,
-                Map.of(
-                        "speed", 100L,
-                        "rpm", 2000L,
-                        "fuelLevel", 12345L
+                Map.ofEntries(
+                        Map.entry("speed", 100L),
+                        Map.entry("rpm", 2000L),
+                        Map.entry("fuelLevel", 12345L)
                 ),
-                List.of("OIL_TEMPERATURE", "TIRE_PRESSURE")
+                new ArrayList<String>() {{
+                    add("OIL_TEMPERATURE");
+                    add("TIRE_PRESSURE");
+                }}
         );
 
         // Serialize and deserialize the record forcing Kryo
         // This will fail if Flink has to fallback to Kryo
-        VehicleEvent deserialized =  FlinkSerializationTestUtils.serializeDeserializeNoKryo(record, VehicleEvent.class);
+        VehicleEvent deserialized = FlinkSerializationTestUtils.serializeDeserializeNoKryo(record, VehicleEvent.class);
 
         // Compare the original record with the deserialized record
         // If you made a mistake in defining the TypeInfo, this comparison will fail

--- a/java/Serialization/CustomTypeInfo/src/test/resources/log4j2-test.properties
+++ b/java/Serialization/CustomTypeInfo/src/test/resources/log4j2-test.properties
@@ -1,0 +1,13 @@
+appender.console.name = ConsoleAppender
+appender.console.type = CONSOLE
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{HH:mm:ss,SSS} %-5p %-60c %x - %m%n
+
+# Display messages of serialization tests
+logger.tracing.name = org.apache.flink.api.java.typeutils.TypeExtractor
+logger.tracing.level = INFO
+logger.tracing.additivity = false
+logger.tracing.appenderRef.console.ref = ConsoleAppender
+
+rootLogger.level = ERROR
+rootLogger.appenderRef.console.ref = ConsoleAppender

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -29,5 +29,6 @@
         <module>S3ParquetSink</module>
         <module>S3Sink</module>
         <module>Windowing</module>
+        <module>Serialization/CustomTypeInfo</module>
     </modules>
 </project>


### PR DESCRIPTION
## Purpose of the change

This example demonstrates how to implement a custom TypeInfo and how to test the serialization of an object.

## Verifying this change

Covered by unit tests

## Significant changes

- [X] Completely new example
- [ ] Updated an existing example to newer Flink version or dependencies versions
- [ ] Improved an existing example
- [ ] Modified the runtime configuration of an existing example (i.e. added/removed/modified any runtime properties)
- [ ] Modified the expected input or output of an existing example (e.g. modified the source or sink, modified the record schema)