### PR TITLE
Update aws connector version

### DIFF
--- a/java/AsyncIO/pom.xml
+++ b/java/AsyncIO/pom.xml
@@ -17,7 +17,7 @@
         <maven.compiler.source>${target.java.version}</maven.compiler.source>
         <maven.compiler.target>${target.java.version}</maven.compiler.target>
         <flink.version>1.20.0</flink.version>
-        <flink.connector.version>4.3.0-1.19</flink.connector.version>
+        <flink.connector.version>5.0.0-1.20</flink.connector.version>
         <kda.runtime.version>1.2.0</kda.runtime.version>
         <log4j.version>2.23.1</log4j.version>
         <jackson.version>2.16.2</jackson.version>
@@ -67,7 +67,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-connector-kinesis</artifactId>
+            <artifactId>flink-connector-aws-kinesis-streams</artifactId>
             <version>${flink.connector.version}</version>
         </dependency>
         <dependency>

--- a/java/AsyncIO/src/main/java/com/amazonaws/services/msf/ProcessingFunction.java
+++ b/java/AsyncIO/src/main/java/com/amazonaws/services/msf/ProcessingFunction.java
@@ -1,9 +1,10 @@
 package com.amazonaws.services.msf;
 
-import com.google.common.base.Preconditions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.functions.async.ResultFuture;
 import org.apache.flink.streaming.api.functions.async.RichAsyncFunction;
+import org.apache.flink.util.Preconditions;
+
 import org.asynchttpclient.AsyncHttpClient;
 import org.asynchttpclient.DefaultAsyncHttpClientConfig;
 import org.asynchttpclient.Dsl;

--- a/java/AsyncIO/src/main/java/com/amazonaws/services/msf/RetriesFlinkJob.java
+++ b/java/AsyncIO/src/main/java/com/amazonaws/services/msf/RetriesFlinkJob.java
@@ -1,7 +1,6 @@
 package com.amazonaws.services.msf;
 
 import com.amazonaws.services.kinesisanalytics.runtime.KinesisAnalyticsRuntime;
-import com.google.common.base.Preconditions;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.serialization.SimpleStringSchema;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
@@ -17,6 +16,8 @@ import org.apache.flink.streaming.api.functions.async.AsyncFunction;
 import org.apache.flink.streaming.api.functions.async.AsyncRetryStrategy;
 import org.apache.flink.streaming.util.retryable.AsyncRetryStrategies;
 import org.apache.flink.streaming.util.retryable.RetryPredicates;
+import org.apache.flink.util.Preconditions;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/java/CustomMetrics/pom.xml
+++ b/java/CustomMetrics/pom.xml
@@ -17,7 +17,7 @@
         <maven.compiler.source>${target.java.version}</maven.compiler.source>
         <maven.compiler.target>${target.java.version}</maven.compiler.target>
         <flink.version>1.20.0</flink.version>
-        <flink.connector.version>4.3.0-1.19</flink.connector.version>
+        <flink.connector.version>5.0.0-1.20</flink.connector.version>
         <kda.runtime.version>1.2.0</kda.runtime.version>
         <log4j.version>2.23.1</log4j.version>
         <jackson.version>2.16.2</jackson.version>
@@ -75,7 +75,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-connector-kinesis</artifactId>
+            <artifactId>flink-connector-aws-kinesis-streams</artifactId>
             <version>${flink.connector.version}</version>
         </dependency>
         <dependency>

--- a/java/GettingStarted/pom.xml
+++ b/java/GettingStarted/pom.xml
@@ -17,7 +17,7 @@
         <maven.compiler.source>${target.java.version}</maven.compiler.source>
         <maven.compiler.target>${target.java.version}</maven.compiler.target>
         <flink.version>1.20.0</flink.version>
-        <aws.connector.version>4.3.0-1.19</aws.connector.version>
+        <aws.connector.version>5.0.0-1.20</aws.connector.version>
         <kda.runtime.version>1.2.0</kda.runtime.version>
         <log4j.version>2.23.1</log4j.version>
     </properties>

--- a/java/KinesisConnectors/README.md
+++ b/java/KinesisConnectors/README.md
@@ -21,16 +21,16 @@ or, when running locally, from the [`resources/flink-application-properties-dev.
 
 All parameters are case-sensitive.
 
-| Group ID        | Key           | Description               | 
-|-----------------|---------------|---------------------------|
-| `InputStream0`  | `stream.arn` | ARN of the input stream.  |
-| `InputStream0`  | `aws.region`  | Region of the input stream. |
-| `InputStream0`  | `kinesis.stream.init.position` | (optional) Starting position when the application starts with no state. Default is `LATEST`|
-| `InputStream0` | `kinesis.stream.reader.type` | (optional) Choose between standard (`POLLING`) and Enhanced Fan-Out (`EFO`) consumer. Default is `POLLING`. |
-| `InputStream0` | `kinesis.stream.efo.consumer.name` | (optional, for EFO consumer mode only) Name of the EFO consumer. Only used if `kinesis.stream.reader.type=EFO`. |
-| `InputStream0` | `kinesis.stream.efo.consumer.lifecycle` | (optional, for EFO consumer mode only) Lifecycle management mode of EFO consumer. Choose between `JOB_MANAGED` and `SELF_MANAGED`. Default is `JOB_MANAGED`. |
-| `OutputStream0` | `stream.arn` | ARN of the output stream. |
-| `OutputStream0`  | `aws.region`  | Region of the output stream. |
+| Group ID        | Key                             | Description                                                                                                                                                  | 
+|-----------------|---------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `InputStream0`  | `stream.arn`                    | ARN of the input stream.                                                                                                                                     |
+| `InputStream0`  | `aws.region`                    | Region of the input stream.                                                                                                                                  |
+| `InputStream0`  | `source.init.position`          | (optional) Starting position when the application starts with no state. Default is `LATEST`                                                                  |
+| `InputStream0` | `source.reader.type`            | (optional) Choose between standard (`POLLING`) and Enhanced Fan-Out (`EFO`) consumer. Default is `POLLING`.                                                  |
+| `InputStream0` | `source.efo.consumer.name`      | (optional, for EFO consumer mode only) Name of the EFO consumer. Only used if `source.reader.type=EFO`.                                                      |
+| `InputStream0` | `source.efo.consumer.lifecycle` | (optional, for EFO consumer mode only) Lifecycle management mode of EFO consumer. Choose between `JOB_MANAGED` and `SELF_MANAGED`. Default is `JOB_MANAGED`. |
+| `OutputStream0` | `stream.arn`                    | ARN of the output stream.                                                                                                                                    |
+| `OutputStream0`  | `aws.region`                    | Region of the output stream.                                                                                                                                 |
 
 Every parameter in the `InputStream0` group is passed to the Kinesis consumer, and every parameter in the `OutputStream0` is passed to the Kinesis client of the sink.
 

--- a/java/KinesisConnectors/pom.xml
+++ b/java/KinesisConnectors/pom.xml
@@ -17,7 +17,7 @@
         <maven.compiler.source>${target.java.version}</maven.compiler.source>
         <maven.compiler.target>${target.java.version}</maven.compiler.target>
         <flink.version>1.20.0</flink.version>
-        <aws.connector.version>4.3.0-1.19</aws.connector.version>
+        <aws.connector.version>5.0.0-1.20</aws.connector.version>
         <kda.runtime.version>1.2.0</kda.runtime.version>
         <log4j.version>2.23.1</log4j.version>
     </properties>

--- a/java/KinesisConnectors/src/main/resources/flink-application-properties-dev.json
+++ b/java/KinesisConnectors/src/main/resources/flink-application-properties-dev.json
@@ -3,7 +3,7 @@
     "PropertyGroupId": "InputStream0",
     "PropertyMap": {
       "stream.arn": "arn:aws:kinesis:us-east-1:012345678900:stream/ExampleInputStream",
-      "kinesis.stream.init.position": "LATEST",
+      "source.init.position": "LATEST",
       "aws.region": "us-east-1"
     }
   },

--- a/java/KinesisFirehoseSink/pom.xml
+++ b/java/KinesisFirehoseSink/pom.xml
@@ -17,7 +17,7 @@
         <maven.compiler.source>${target.java.version}</maven.compiler.source>
         <maven.compiler.target>${target.java.version}</maven.compiler.target>
         <flink.version>1.20.0</flink.version>
-        <flink.connector.version>4.3.0-1.19</flink.connector.version>
+        <flink.connector.version>5.0.0-1.20</flink.connector.version>
         <kda.runtime.version>1.2.0</kda.runtime.version>
         <log4j.version>2.23.1</log4j.version>
     </properties>

--- a/java/S3Sink/pom.xml
+++ b/java/S3Sink/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.source>${target.java.version}</maven.compiler.source>
         <maven.compiler.target>${target.java.version}</maven.compiler.target>
         <flink.version>1.20.0</flink.version>
-        <flink.connector.version>4.3.0-1.19</flink.connector.version>
+        <flink.connector.version>5.0.0-1.20</flink.connector.version>
         <kda.runtime.version>1.2.0</kda.runtime.version>
         <log4j.version>2.23.1</log4j.version>
     </properties>

--- a/java/Serialization/CustomTypeInfo/pom.xml
+++ b/java/Serialization/CustomTypeInfo/pom.xml
@@ -17,7 +17,7 @@
         <maven.compiler.source>${target.java.version}</maven.compiler.source>
         <maven.compiler.target>${target.java.version}</maven.compiler.target>
         <flink.version>1.20.0</flink.version>
-        <aws.connector.version>4.3.0-1.19</aws.connector.version>
+        <aws.connector.version>5.0.0-1.20</aws.connector.version>
         <kda.runtime.version>1.2.0</kda.runtime.version>
         <log4j.version>2.23.1</log4j.version>
         <junit5.version>5.8.1</junit5.version>
@@ -74,7 +74,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-connector-kinesis</artifactId>
+            <artifactId>flink-connector-aws-kinesis-streams</artifactId>
             <version>${aws.connector.version}</version>
         </dependency>
 

--- a/java/SideOutputs/pom.xml
+++ b/java/SideOutputs/pom.xml
@@ -17,7 +17,7 @@
         <maven.compiler.source>${target.java.version}</maven.compiler.source>
         <maven.compiler.target>${target.java.version}</maven.compiler.target>
         <flink.version>1.20.0</flink.version>
-        <flink.connector.version>4.3.0-1.19</flink.connector.version>
+        <flink.connector.version>5.0.0-1.20</flink.connector.version>
         <kda.runtime.version>1.2.0</kda.runtime.version>
         <log4j.version>2.23.1</log4j.version>
         <jackson.version>2.16.2</jackson.version>
@@ -62,7 +62,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-connector-kinesis</artifactId>
+            <artifactId>flink-connector-aws-kinesis-streams</artifactId>
             <version>${flink.connector.version}</version>
         </dependency>
         <dependency>

--- a/java/Windowing/pom.xml
+++ b/java/Windowing/pom.xml
@@ -17,7 +17,7 @@
         <maven.compiler.source>${target.java.version}</maven.compiler.source>
         <maven.compiler.target>${target.java.version}</maven.compiler.target>
         <flink.version>1.20.0</flink.version>
-        <aws.connector.version>4.3.0-1.19</aws.connector.version>
+        <aws.connector.version>5.0.0-1.20</aws.connector.version>
         <kda.runtime.version>1.2.0</kda.runtime.version>
         <log4j.version>2.23.1</log4j.version>
         <jackson.version>2.17.0</jackson.version>
@@ -80,7 +80,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-connector-kinesis</artifactId>
+            <artifactId>flink-connector-aws-kinesis-streams</artifactId>
             <version>${aws.connector.version}</version>
         </dependency>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -15,6 +15,7 @@
     It's only used to simplify importing all Java examples in your IDE or building all of them.
     You can still import each project independently, if you prefer. -->
     <modules>
+        <module>AsyncIO</module>
         <module>AvroGlueSchemaRegistryKafka</module>
         <module>AvroGlueSchemaRegistryKinesis</module>
         <module>CustomMetrics</module>
@@ -31,6 +32,7 @@
         <module>S3Sink</module>
         <module>Windowing</module>
         <module>Serialization/CustomTypeInfo</module>
+        <module>SideOutputs</module>
         <module>PrometheusSink</module>
     </modules>
 </project>


### PR DESCRIPTION
## Purpose of the change

- Update the AWS connectors across all examples to the latest release version of 5.0.0
- Update the Kinesis connector artifact to use the latest `flink-connector-aws-kinesis-streams` instead of the deprecated `flink-connector-kinesis` artifacts.

## Verifying this change

This is a trivial upgrade for DataStream API examples, since the classes used are still available.

## Significant changes

*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterward, for convenience.)*

- [ ] Completely new example
- [x] Updated an existing example to newer Flink version or dependencies versions
- [ ] Improved an existing example
- [ ] Modified the runtime configuration of an existing example (i.e. added/removed/modified any runtime properties)
- [ ] Modified the expected input or output of an existing example (e.g. modified the source or sink, modified the record schema)