### PR TITLE
Migrate Kinesis Streaming Job from string serialization to JSON.

### DIFF
--- a/java/KinesisConnectors/README.md
+++ b/java/KinesisConnectors/README.md
@@ -12,6 +12,10 @@ It also shows how to set up an **Enhanced Fan-Out (EFO)** source.
 
 This example uses `FlinkKinesisConsumer` and `KinesisStreamsSink` connectors.
 
+This example expects a JSON payload as input and outputs a corresponding JSON output. 
+The JSON input follows the structure set in `Stock.java` and can be automatically generated with
+`stock.py` under the python directory.
+
 ![Flink Example](images/flink-kinesis-example.png)
 
 ### Runtime configuration

--- a/java/KinesisConnectors/pom.xml
+++ b/java/KinesisConnectors/pom.xml
@@ -101,12 +101,6 @@
             <artifactId>log4j-core</artifactId>
             <version>${log4j.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-json</artifactId>
-            <version>1.20.0</version>
-            <scope>compile</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/java/KinesisConnectors/pom.xml
+++ b/java/KinesisConnectors/pom.xml
@@ -56,6 +56,12 @@
             <version>${flink.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-json</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- Library to retrieve runtime application properties in Managed Service for Apache Flink  -->
         <dependency>
@@ -94,6 +100,12 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
             <version>${log4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-json</artifactId>
+            <version>1.20.0</version>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 

--- a/java/KinesisConnectors/src/main/java/com/amazonaws/services/msf/Stock.java
+++ b/java/KinesisConnectors/src/main/java/com/amazonaws/services/msf/Stock.java
@@ -1,21 +1,45 @@
 package com.amazonaws.services.msf;
 
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
 public class Stock {
-    public String event_time;
-    public String ticker;
-    public float price;
+    // This annotation as well as the associated jackson2 import is needed to correctly map the JSON input key to the
+    // appropriate POJO property name to ensure event_time isn't missed in serialization and deserialization
+    @JsonProperty("event_time")
+    private String eventTime;
+    private String ticker;
+    private float price;
 
     public Stock() {}
 
-    public Stock mutateTicker(String ticker) {
+    public String getEventTime() {
+        return eventTime;
+    }
+
+    public void setEventTime(String eventTime) {
+        this.eventTime = eventTime;
+    }
+
+    public String getTicker() {
+        return ticker;
+    }
+
+    public void setTicker(String ticker) {
         this.ticker = ticker;
-        return this;
+    }
+
+    public float getPrice() {
+        return price;
+    }
+
+    public void setPrice(float price) {
+        this.price = price;
     }
 
     @Override
     public String toString() {
         return "Stock{" +
-                "event_time='" + event_time + '\'' +
+                "event_time='" + eventTime + '\'' +
                 ", ticker='" + ticker + '\'' +
                 ", price=" + price +
                 '}';

--- a/java/KinesisConnectors/src/main/java/com/amazonaws/services/msf/Stock.java
+++ b/java/KinesisConnectors/src/main/java/com/amazonaws/services/msf/Stock.java
@@ -1,9 +1,23 @@
 package com.amazonaws.services.msf;
 
 public class Stock {
-    private String event_time;
-    private String ticker;
-    private float price;
+    public String event_time;
+    public String ticker;
+    public float price;
 
     public Stock() {}
+
+    public Stock mutateTicker(String ticker) {
+        this.ticker = ticker;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return "Stock{" +
+                "event_time='" + event_time + '\'' +
+                ", ticker='" + ticker + '\'' +
+                ", price=" + price +
+                '}';
+    }
 }

--- a/java/KinesisConnectors/src/main/java/com/amazonaws/services/msf/Stock.java
+++ b/java/KinesisConnectors/src/main/java/com/amazonaws/services/msf/Stock.java
@@ -2,7 +2,7 @@ package com.amazonaws.services.msf;
 
 public class Stock {
     private String event_time;
-    public String ticker;
+    private String ticker;
     private float price;
 
     public Stock() {}

--- a/java/KinesisConnectors/src/main/java/com/amazonaws/services/msf/Stock.java
+++ b/java/KinesisConnectors/src/main/java/com/amazonaws/services/msf/Stock.java
@@ -1,0 +1,9 @@
+package com.amazonaws.services.msf;
+
+public class Stock {
+    private String event_time;
+    public String ticker;
+    private float price;
+
+    public Stock() {}
+}

--- a/java/KinesisConnectors/src/main/java/com/amazonaws/services/msf/StreamingJob.java
+++ b/java/KinesisConnectors/src/main/java/com/amazonaws/services/msf/StreamingJob.java
@@ -66,13 +66,6 @@ public class StreamingJob {
                 .build();
     }
 
-    private static <T> DataStream<T> createDataStream(final StreamExecutionEnvironment env, TypeInformation<T> typeInformation, KinesisStreamsSource<T> source) {
-        return env.fromSource(source,
-                WatermarkStrategy.noWatermarks(),
-                "Kinesis source",
-                typeInformation);
-    }
-
     public static void main(String[] args) throws Exception {
         // set up the streaming execution environment
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
@@ -87,7 +80,7 @@ public class StreamingJob {
                 "Kinesis source",
                 TypeInformation.of(Stock.class));
 
-        input.map(stock -> stock.mutateTicker("AMZN")).sinkTo(sink);
+        input.sinkTo(sink);
         env.execute("Flink Kinesis Source and Sink examples");
     }
 }

--- a/java/KinesisConnectors/src/main/java/com/amazonaws/services/msf/StreamingJob.java
+++ b/java/KinesisConnectors/src/main/java/com/amazonaws/services/msf/StreamingJob.java
@@ -6,7 +6,6 @@ import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.api.common.serialization.SimpleStringSchema;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.api.connector.sink.Sink;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.kinesis.sink.KinesisStreamsSink;
 import org.apache.flink.connector.kinesis.source.KinesisStreamsSource;

--- a/java/KinesisConnectors/src/main/resources/flink-application-properties-dev.json
+++ b/java/KinesisConnectors/src/main/resources/flink-application-properties-dev.json
@@ -13,5 +13,11 @@
       "stream.arn": "arn:aws:kinesis:us-east-1:012345678900:stream/ExampleOutputStream",
       "aws.region": "us-east-1"
     }
+  },
+  {
+    "PropertyGroupId": "SerializationType",
+    "PropertyMap": {
+      "type": "JSON"
+    }
   }
 ]

--- a/java/KinesisConnectors/src/main/resources/flink-application-properties-dev.json
+++ b/java/KinesisConnectors/src/main/resources/flink-application-properties-dev.json
@@ -13,11 +13,5 @@
       "stream.arn": "arn:aws:kinesis:us-east-1:012345678900:stream/ExampleOutputStream",
       "aws.region": "us-east-1"
     }
-  },
-  {
-    "PropertyGroupId": "SerializationType",
-    "PropertyMap": {
-      "type": "JSON"
-    }
   }
 ]


### PR DESCRIPTION
<!--
*Thank you for contributing to the Amazon Managed Service for Apache Flink examples - we are happy that you want to help us improve our examples. Please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

- Verify your PR follows the contribution recommendation of the repository
- Each PR should add/modify a single example and address a single concern
- Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

## Purpose of the change

Modifies the Kinesis Connector from using string serialization to JSON object serialization and deserialization.

## Verifying this change

Tested through MSF and locally by ensuring that the deserialized output matched the serialized input except that the output contained only the AMZN ticker. 

Input:
<img width="673" alt="image" src="https://github.com/user-attachments/assets/8846adef-3b06-4f22-8cb4-8c14a8801dad" />

Output: 
<img width="683" alt="image" src="https://github.com/user-attachments/assets/6d9fc4c0-4e6b-411f-a16b-dedd64123c07" />

## Significant changes

*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterward, for convenience.)*

- [ ] Completely new example
- [ ] Updated an existing example to newer Flink version or dependencies versions
- [x] Improved an existing example
- [x] Modified the runtime configuration of an existing example (i.e. added/removed/modified any runtime properties)
- [x] Modified the expected input or output of an existing example (e.g. modified the source or sink, modified the record schema)