### PR TITLE
Fix Python Getting Started Stream ARN Examples in README

### DIFF
--- a/python/GettingStarted/README.md
+++ b/python/GettingStarted/README.md
@@ -56,14 +56,14 @@ When running locally, the configuration is read from the [`application_propertie
 
 Runtime parameters:
 
-| Group ID        | Key                            | Mandatory | Example Value             | Notes                                                                         |
-|-----------------|--------------------------------|-----------|---------------------------|-------------------------------------------------------------------------------|
-| `InputStream0`  | `stream.arn`                   | Y         | `ExampleInputStream`      | Input stream ARN.                                                             |
-| `InputStream0`  | `aws.region`                   | Y         | `us-east-1`               | Region for the input stream.                                                  |
-| `InputStream0`  | `flink.source.init.position`   | N         | `LATEST`                  | Stream initial position in the input stream. `LATEST` by default              |
-| `InputStream0`  | `flink.source.init.timestamp`  | N         | `2025-02-17T21:45:42.123` | Initial position timestamp. Ignored unless initial position is `AT_TIMESTAMP` |                    
-| `OutputStream0` | `stream.arn`                   | Y         | `ExampleOutpiutStream`    | Output stream ARN.                                                            |
-| `OutputStream0` | `aws.region`                   | Y         | `us-east-1`               | Region for the output stream.                                                 |
+| Group ID        | Key                            | Mandatory | Example Value                                                     | Notes                                                                         |
+|-----------------|--------------------------------|-----------|-------------------------------------------------------------------|-------------------------------------------------------------------------------|
+| `InputStream0`  | `stream.arn`                   | Y         | `arn:aws:kinesis:<region>:<accountId>:stream/ExampleInputStream`  | Input stream ARN.                                                             |
+| `InputStream0`  | `aws.region`                   | Y         | `us-east-1`                                                       | Region for the input stream.                                                  |
+| `InputStream0`  | `flink.source.init.position`   | N         | `LATEST`                                                          | Stream initial position in the input stream. `LATEST` by default              |
+| `InputStream0`  | `flink.source.init.timestamp`  | N         | `2025-02-17T21:45:42.123`                                         | Initial position timestamp. Ignored unless initial position is `AT_TIMESTAMP` |
+| `OutputStream0` | `stream.arn`                   | Y         | `arn:aws:kinesis:<region>:<accountId>:stream/ExampleOutputStream` | Output stream ARN.                                                            |
+| `OutputStream0` | `aws.region`                   | Y         | `us-east-1`                                                       | Region for the output stream.                                                 |
 
 
 In addition to these configuration properties, when running a PyFlink application in Managed Flink you need to set two


### PR DESCRIPTION
## Purpose of the change

Update runtime configuration examples in the Python GettingStarted README to reflect the correct usage of `stream.arn` instead of `stream.name`. The upgrade from Kinesis connector version 4.3.0-1.19 to 5.0.0-1.20 changed the expected parameter from stream name to stream ARN, but the examples still showed stream names, which could cause confusion.
## Verifying this change

1. tested locally
2. tested on Managed Flink

## Significant changes

*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterward, for convenience.)*

- [ ] Completely new example
- [ ] Updated an existing example to newer Flink version or dependencies versions
- [ ] Improved an existing example
- [x] Modified the runtime configuration of an existing example (i.e. added/removed/modified any runtime properties)
- [ ] Modified the expected input or output of an existing example (e.g. modified the source or sink, modified the record schema)