### PR TITLE
Remove unused dependencies from Kinesis Source deaggregation example 

### DIFF
--- a/java/KinesisSourceDeaggregation/flink-app/pom.xml
+++ b/java/KinesisSourceDeaggregation/flink-app/pom.xml
@@ -82,10 +82,25 @@
             <groupId>software.amazon.kinesis</groupId>
             <artifactId>amazon-kinesis-client</artifactId>
             <version>${kinesis.client.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>retries</artifactId>
+            <!-- Exclude most of the transitive dependencies in KCL because they are not really needed -->
+            <exclusions>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>software.amazon.glue</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.reactivex.rxjava3</groupId>
+                    <artifactId>rxjava</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Connectors and Formats -->


### PR DESCRIPTION
## Purpose of the change

Remove dependencies not required from Kinesis Source deaggregation example


## Significant changes

- [ ] Completely new example
- [ ] Updated an existing example to newer Flink version or dependencies versions
- [X] Improved an existing example
- [ ] Modified the runtime configuration of an existing example (i.e. added/removed/modified any runtime properties)
- [ ] Modified the expected input or output of an existing example (e.g. modified the source or sink, modified the record schema)